### PR TITLE
support mocking vendored dependencies

### DIFF
--- a/mockgen/model/model.go
+++ b/mockgen/model/model.go
@@ -343,6 +343,13 @@ func typeFromType(t reflect.Type) (Type, error) {
 	}
 
 	if imp := t.PkgPath(); imp != "" {
+		// PkgPath might return a path that includes "vendor"
+		// These paths do not compile, so we need to remove everything
+		// up to and including "/vendor/"
+		// see https://github.com/golang/go/issues/12019
+		if i := strings.LastIndex(imp, "/vendor/"); i != -1 {
+			imp = imp[i+len("/vendor/"):]
+		}
 		return &NamedType{
 			Package: imp,
 			Type:    t.Name(),

--- a/mockgen/reflect.go
+++ b/mockgen/reflect.go
@@ -41,8 +41,13 @@ func Reflect(importPath string, symbols []string) (*model.Package, error) {
 
 	progPath := *execOnly
 	if *execOnly == "" {
+		// Put program in working directory to pick up packages in vendor/ during build
+		wDir, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
 		// We use TempDir instead of TempFile so we can control the filename.
-		tmpDir, err := ioutil.TempDir("", "gomock_reflect_")
+		tmpDir, err := ioutil.TempDir(wDir, "gomock_reflect_")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Generate temporary program in current directory tree to pick up vendored dependencies during build
- Clean up the return of `PkgPath` according to the advice of rsc here https://github.com/golang/go/issues/12019#issuecomment-148747953